### PR TITLE
fix(patch): check for swiftui variables as member types

### DIFF
--- a/Tests/EquatableMacroTests.swift
+++ b/Tests/EquatableMacroTests.swift
@@ -128,6 +128,54 @@ struct EquatableMacroTests {
             """
         }
     }
+    
+    @Test
+    func memberSwiftUIWrappedPropertiesSkipped() async throws {
+        assertMacro {
+            """
+            @Equatable
+            struct TitleView: View {
+                @SwiftUI.State var dataModel = TitleDataModel()
+                @SwiftUI.Environment(\\.colorScheme) var colorScheme
+                @SwiftUI.StateObject private var viewModel = TitleViewModel()
+                @SwiftUI.ObservedObject var anotherViewModel = AnotherViewModel()
+                @SwiftUI.FocusState var isFocused: Bool
+                @SwiftUI.SceneStorage("title") var title: String = "Default Title"
+                @SwiftUI.AppStorage("title") var appTitle: String = "App Title"
+                static let staticInt: Int = 42
+                let title: String
+
+                var body: some View {
+                    Text(title)
+                }
+            }
+            """
+        } expansion: {
+            """
+            struct TitleView: View {
+                @SwiftUI.State var dataModel = TitleDataModel()
+                @SwiftUI.Environment(\\.colorScheme) var colorScheme
+                @SwiftUI.StateObject private var viewModel = TitleViewModel()
+                @SwiftUI.ObservedObject var anotherViewModel = AnotherViewModel()
+                @SwiftUI.FocusState var isFocused: Bool
+                @SwiftUI.SceneStorage("title") var title: String = "Default Title"
+                @SwiftUI.AppStorage("title") var appTitle: String = "App Title"
+                static let staticInt: Int = 42
+                let title: String
+
+                var body: some View {
+                    Text(title)
+                }
+            }
+
+            extension TitleView: Equatable {
+                nonisolated public static func == (lhs: TitleView, rhs: TitleView) -> Bool {
+                    lhs.title == rhs.title
+                }
+            }
+            """
+        }
+    }
 
     @Test
     func markedWithEquatableIgnoredSkipped() async throws {


### PR DESCRIPTION
## Description

We skip over variables defined from the SwiftUI lifecycle infra such as `State`:

```swift
@State var name: String
```

But we are not skipping over variables defined when we also specify the `SwiftUI` module:

```swift
@SwiftUI.State var name: String
```

We can make a small change to support that.

## How Has This Been Tested?

New test was added.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
