### PR TITLE
fix(patch): allow @Equatable on types without stored properties

### DIFF
--- a/Sources/EquatableMacros/EquatableMacro.swift
+++ b/Sources/EquatableMacros/EquatableMacro.swift
@@ -132,7 +132,7 @@ public struct EquatableMacro: ExtensionMacro {
             }
 
             // Skip static properties
-            if Self.isStatic(varDecl) {
+            if varDecl.isStatic {
                 return nil
             }
 
@@ -180,7 +180,7 @@ public struct EquatableMacro: ExtensionMacro {
         }
 
         // Check if the type conforms to `Hashable`
-        if Self.isHashable(structDecl) {
+        if structDecl.isHashable {
             // If the type conforms to `Hashable` we need to generate the `Hashable` conformance to match
             // the properties used in `Equatable` implementation
             guard let hashableExtensionSyntax = Self.generateHashableExtensionSyntax(
@@ -237,19 +237,6 @@ extension EquatableMacro {
             return true
         }
         return false
-    }
-
-    private static func isStatic(_ varDecl: VariableDeclSyntax) -> Bool {
-        varDecl.modifiers.contains { modifier in
-            modifier.name.tokenKind == .keyword(.static)
-        }
-    }
-
-    private static func isHashable(_ structDecl: StructDeclSyntax) -> Bool {
-        let existingConformances = structDecl.inheritanceClause?.inheritedTypes
-            .compactMap { $0.type.as(IdentifierTypeSyntax.self)?.name.text }
-        ?? []
-        return existingConformances.contains("Hashable")
     }
 
     private static func isMarkedWithEquatableIgnoredUnsafeClosure(_ varDecl: VariableDeclSyntax) -> Bool {

--- a/Sources/EquatableMacros/Extensions/StructDeclSyntax+Extensions.swift
+++ b/Sources/EquatableMacros/Extensions/StructDeclSyntax+Extensions.swift
@@ -1,0 +1,10 @@
+import SwiftSyntax
+
+extension StructDeclSyntax {
+    var isHashable: Bool {
+        let existingConformances = self.inheritanceClause?.inheritedTypes
+            .compactMap { $0.type.as(IdentifierTypeSyntax.self)?.name.text }
+        ?? []
+        return existingConformances.contains("Hashable")
+    }
+}

--- a/Sources/EquatableMacros/Extensions/VariableDeclSyntax+Extensions.swift
+++ b/Sources/EquatableMacros/Extensions/VariableDeclSyntax+Extensions.swift
@@ -1,0 +1,9 @@
+import SwiftSyntax
+
+extension VariableDeclSyntax {
+    var isStatic: Bool {
+        self.modifiers.contains { modifier in
+            modifier.name.tokenKind == .keyword(.static)
+        }
+    }
+}

--- a/Tests/EquatableMacroTests.swift
+++ b/Tests/EquatableMacroTests.swift
@@ -322,8 +322,6 @@ struct EquatableMacroTests {
         } diagnostics: {
             """
             @Equatable
-            ┬─────────
-            ╰─ 🛑 @Equatable requires at least one equatable stored property.
             struct CustomView: View {
                 @EquatableIgnored @Binding var name: String
                 ┬────────────────
@@ -351,12 +349,10 @@ struct EquatableMacroTests {
             }
             """
         } diagnostics: {
-            """
+            #"""
             @Equatable
-            ┬─────────
-            ╰─ 🛑 @Equatable requires at least one equatable stored property.
             struct CustomView: View {
-                @EquatableIgnored @FocusedBinding(\\.focusedBinding) var focusedBinding
+                @EquatableIgnored @FocusedBinding(\.focusedBinding) var focusedBinding
                 ┬────────────────
                 ╰─ 🛑 @EquatableIgnored cannot be applied to @FocusedBinding properties
 
@@ -364,7 +360,7 @@ struct EquatableMacroTests {
                     Text("CustomView")
                 }
             }
-            """
+            """#
         }
     }
 
@@ -482,27 +478,65 @@ struct EquatableMacroTests {
             @Equatable
             struct NoProperties: View {
                 @EquatableIgnoredUnsafeClosure let onTap: () -> Void
-
-                var body: some View {
-                    Text("")
-                }
-            }
-            """
-        } diagnostics: {
-            """
-            @Equatable
-            ┬─────────
-            ╰─ 🛑 @Equatable requires at least one equatable stored property.
-            struct NoProperties: View {
-                @EquatableIgnoredUnsafeClosure let onTap: () -> Void
-
+            
                 var body: some View {
                     Text("")
                 }
             }
             """
         } expansion: {
-            ""
+            """
+            struct NoProperties: View {
+                let onTap: () -> Void
+
+                var body: some View {
+                    Text("")
+                }
+            }
+
+            extension NoProperties: Equatable {
+                nonisolated public static func == (lhs: NoProperties, rhs: NoProperties) -> Bool {
+                    true
+                }
+            }
+            """
+        }
+    }
+
+    @Test
+    func noEquatablePropertiesConformingToHashable() async throws {
+        assertMacro {
+            """
+            @Equatable
+            struct NoProperties: View, Hashable {
+                @EquatableIgnoredUnsafeClosure let onTap: () -> Void
+            
+                var body: some View {
+                    Text("")
+                }
+            }
+            """
+        } expansion: {
+            """
+            struct NoProperties: View, Hashable {
+                let onTap: () -> Void
+
+                var body: some View {
+                    Text("")
+                }
+            }
+
+            extension NoProperties: Equatable {
+                nonisolated public static func == (lhs: NoProperties, rhs: NoProperties) -> Bool {
+                    true
+                }
+            }
+
+            extension NoProperties {
+                nonisolated public func hash(into hasher: inout Hasher) {
+                }
+            }
+            """
         }
     }
 


### PR DESCRIPTION
## Description

Allow `@Equatable` to be applied on types without stored properties.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [x] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
