### PR TITLE
fix(patch): package platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
     name: "Equatable",
-    platforms: [.macOS(.v12), .iOS(.v15), .tvOS(.v15), .watchOS(.v8), .macCatalyst(.v15)],
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/EquatableClient/main.swift
+++ b/Sources/EquatableClient/main.swift
@@ -107,6 +107,7 @@ struct BandView: View {
 
 final class ProfileViewModel: ObservableObject {}
 
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 @Equatable
 struct ProfileView: View {
     var username: String // Will be compared


### PR DESCRIPTION
## Description

Our current package depends on macOS 12. There does not seem to be anything inside the macro itself that depends on macOS 12. The only place we seem to depend on macOS 12 is one place in our `EquatableClient` target. We can gate that code with `available` and then adjust the package platforms to macOS 10.15. We support two additional years of OS releases this way.

## How Has This Been Tested?

Building locally.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
