### PR TITLE
fix(minor): Recognize actor-annotated closures in macro validation

### DIFF
--- a/Sources/EquatableMacros/Closure.swift
+++ b/Sources/EquatableMacros/Closure.swift
@@ -1,6 +1,10 @@
 import SwiftSyntax
 
 func isClosure(type: TypeSyntax) -> Bool {
+    if let attributedType = type.as(AttributedTypeSyntax.self) {
+        return isClosure(type: attributedType.baseType)
+    }
+
     if type.is(FunctionTypeSyntax.self) {
         return true
     }

--- a/Tests/EquatableMacroTests.swift
+++ b/Tests/EquatableMacroTests.swift
@@ -484,6 +484,42 @@ struct EquatableMacroTests {
     }
 
     @Test
+    func equatableIgnoredCannotBeAppliedToMainActorClosures() async throws {
+        assertMacroExpansion(
+            """
+            struct CustomView: View {
+                @EquatableIgnored var closure: @MainActor () -> Void
+                var name: String
+
+                var body: some View {
+                    Text("CustomView")
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct CustomView: View {
+                var closure: @MainActor () -> Void
+                var name: String
+
+                var body: some View {
+                    Text("CustomView")
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "@EquatableIgnored cannot be applied to closures",
+                    line: 2,
+                    column: 5
+                )
+            ],
+            macroSpecs: macroSpecs,
+            failureHandler: failureHander
+        )
+    }
+
+    @Test
     func equatableIgnoredCannotBeAppliedToBindings() async throws {
         assertMacroExpansion(
             """
@@ -659,6 +695,75 @@ struct EquatableMacroTests {
     }
 
     @Test(arguments: testArguments)
+    func arbitaryMainActorClosuresNotAllowed(isolation: Isolation) async throws {
+        let macro = EquatableMacroTests.equatableMacro(for: isolation)
+        let generatedConformance = switch isolation {
+        case .nonisolated:
+            """
+            extension CustomView: Equatable {
+                nonisolated public static func == (lhs: Self, rhs: Self) -> Bool {
+                    lhs.name == rhs.name
+                }
+            }
+            """
+        case .isolated:
+            """
+            extension CustomView: Equatable {
+                public static func == (lhs: Self, rhs: Self) -> Bool {
+                    lhs.name == rhs.name
+                }
+            }
+            """
+        case .main:
+            """
+            extension CustomView: @MainActor Equatable {
+                public static func == (lhs: Self, rhs: Self) -> Bool {
+                    lhs.name == rhs.name
+                }
+            }
+            """
+        }
+        assertMacroExpansion(
+            """
+            \(macro)
+            struct CustomView: View {
+                var name: String
+                let closure: (@MainActor () -> Void)?
+
+                var body: some View {
+                    Text("CustomView")
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct CustomView: View {
+                var name: String
+                let closure: (@MainActor () -> Void)?
+
+                var body: some View {
+                    Text("CustomView")
+                }
+            }
+
+            \(generatedConformance)
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "Arbitary closures are not supported in @Equatable",
+                    line: 4,
+                    column: 5,
+                    fixIts: [
+                        FixItSpec(message: "Consider marking the closure with@EquatableIgnoredUnsafeClosure if it doesn't effect the view's body output.")
+                    ]
+                )
+            ],
+            macroSpecs: macroSpecs,
+            failureHandler: failureHander
+        )
+    }
+
+    @Test(arguments: testArguments)
     func closuresMarkedWithEquatableIgnoredUnsafeClosure(isolation: Isolation) async throws {
         let macro = EquatableMacroTests.equatableMacro(for: isolation)
         let generatedConformance = switch isolation {
@@ -703,6 +808,65 @@ struct EquatableMacroTests {
             """
             struct CustomView: View {
                 let closure: (() -> Void)?
+                var name: String
+
+                var body: some View {
+                    Text("CustomView")
+                }
+            }
+
+            \(generatedConformance)
+            """,
+            macroSpecs: macroSpecs,
+            failureHandler: failureHander
+        )
+    }
+
+    @Test(arguments: testArguments)
+    func mainActorClosuresMarkedWithEquatableIgnoredUnsafeClosure(isolation: Isolation) async throws {
+        let macro = EquatableMacroTests.equatableMacro(for: isolation)
+        let generatedConformance = switch isolation {
+        case .nonisolated:
+            """
+            extension CustomView: Equatable {
+                nonisolated public static func == (lhs: Self, rhs: Self) -> Bool {
+                    lhs.name == rhs.name
+                }
+            }
+            """
+        case .isolated:
+            """
+            extension CustomView: Equatable {
+                public static func == (lhs: Self, rhs: Self) -> Bool {
+                    lhs.name == rhs.name
+                }
+            }
+            """
+        case .main:
+            """
+            extension CustomView: @MainActor Equatable {
+                public static func == (lhs: Self, rhs: Self) -> Bool {
+                    lhs.name == rhs.name
+                }
+            }
+            """
+        }
+        assertMacroExpansion(
+            """
+            \(macro)
+            struct CustomView: View {
+                @EquatableIgnoredUnsafeClosure let closure: (@MainActor () -> Void)?
+                var name: String
+
+                var body: some View {
+                    Text("CustomView")
+                }
+            }
+            """,
+            expandedSource:
+            """
+            struct CustomView: View {
+                let closure: (@MainActor () -> Void)?
                 var name: String
 
                 var body: some View {


### PR DESCRIPTION
Unwrap AttributedTypeSyntax in isClosure(type:) so actor-annotated closures are recognized consistently across Equatable macros.

Behavior change:
- @EquatableIgnored rejects actor-annotated closures
- @Equatable diagnoses unignored actor-annotated closures
- @EquatableIgnoredUnsafeClosure accepts actor-annotated closures

## Description

Include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

## How Has This Been Tested?

- Ran `swift test`
- Added regression tests covering anew cases:
  - `@EquatableIgnored` on `@MainActor () -> Void`
  - `@Equatable` on `(@MainActor () -> Void)?`
  - `@EquatableIgnoredUnsafeClosure` on `(@MainActor () -> Void)?`

## Minimal checklist:

- [x ] I have performed a self-review of my own code 
- [  ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
